### PR TITLE
Make some wakeup methods use a very short screen timeout

### DIFF
--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -408,6 +408,20 @@ void Gui::on_power_event(PowerCode_t code, uint32_t arg)
         update_battery_level();
         update_battery_icon(LV_ICON_CALCULATION);
         increment_wakeup_count();
+        switch (arg)
+        {
+            case WAKEUP_BUTTON:
+                clear_temporary_screen_timeout(); // waking up with a button press - if the last timeout was temporary, clear it
+                break;
+            case WAKEUP_ACCELEROMETER: // waking up with double tap or tilt
+                set_temporary_screen_timeout(2);
+                break;
+            //case WAKEUP_TOUCH:                   // not yet implemented
+            //    set_temporary_screen_timeout(2); // change this when it is implemented
+            //    break;
+            default:
+                 clear_temporary_screen_timeout();
+        }
         update_gui();
         lv_disp_trig_activity(NULL);
     }
@@ -567,4 +581,23 @@ void Gui::save_config_to_file(JsonObject &json)
 void Gui::theme_updated()
 {
     bar->theme_updated();
+}
+
+void Gui::set_temporary_screen_timeout(int value)
+{
+    if (!screen_timeout_is_temporary)
+    {
+        saved_screen_timeout = screen_timeout;
+        screen_timeout = value;
+        screen_timeout_is_temporary = true;
+    }
+}
+
+void Gui::clear_temporary_screen_timeout()
+{
+    if (screen_timeout_is_temporary)
+    {
+        screen_timeout = saved_screen_timeout;
+        screen_timeout_is_temporary = false;
+    }
 }

--- a/src/gui.h
+++ b/src/gui.h
@@ -34,6 +34,8 @@ public:
     void toggle_status_bar_icon(lv_icon_status_bar_t icon, bool hidden);
     int get_screen_timeout() { return screen_timeout; }
     void set_screen_timeout(int value) { screen_timeout = value; }
+    void set_temporary_screen_timeout(int value);
+    void clear_temporary_screen_timeout();
     int get_wakeup_count() { return wakeup_count; }
     void increment_wakeup_count() { wakeup_count++; }
     uint8_t get_display_brightness() { return display_brightness; }
@@ -70,6 +72,8 @@ private:
 
     bool time_24hour_format = false;
     int screen_timeout = 10; // only until it's first changed
+    int saved_screen_timeout = 10;
+    bool screen_timeout_is_temporary = false;
     int8_t timezone_id = 0; // Index of the array of timezones in the timezone Roller selector widget
     int wakeup_count = 0; // restarts at zero at each startup
     uint8_t display_brightness = 155; // only until it's first changed

--- a/src/hardware/Hardware.h
+++ b/src/hardware/Hardware.h
@@ -14,6 +14,13 @@ enum PowerCode_t
     WALK_STEP_COUNTER_UPDATED,
 };
 
+enum WakeupSource_t
+{
+    WAKEUP_BUTTON,
+    WAKEUP_ACCELEROMETER,
+    WAKEUP_TOUCH
+};
+
 typedef std::function<void(PowerCode_t, uint32_t)> low_power_callback;
 /**
  * @brief Hardware class purpose is to handle all hardware features of the watch, power managment setup, power event callbacks and BMA interuptions, sound & vibrate stuff (comming soon)


### PR DESCRIPTION
Double-tap and tilt should turn the screen on for only a few seconds - just long enough to read the time, or look at whatever other screen you're on. But pushing the external button should result in a normal screen timeout - the one from Display Settings.

It works, but I can' say that I've tested every possible scenario. (For example, if you're on the Display Settings page, and the watch goes to sleep, and you wake it up with a double-tap, and in the 2 seconds, you try to change the screen timeout... I don't know what will happen.

Also, I haven't yet added code to allow you to double-tap while the watch is awake for just two seconds to "convert" that to the normal screen timeout time. My watch has died, so I can no longer test anything. I'll get a new watch ordered as soon as I can, but in the Bahamas... who knows?

@JohnySeven , please test what I've done, and if you like it, merge it. When I get a new watch, I can resume development on this feature.