### PR TITLE
Add day and date to the display

### DIFF
--- a/src/gui.h
+++ b/src/gui.h
@@ -65,6 +65,7 @@ private:
     lv_obj_t *secondsLabel = NULL;
     lv_obj_t *menuBtn = NULL;
     lv_obj_t *watch_face = NULL;
+    lv_obj_t *dayDateLabel = NULL;
     MenuBar *menuBars = NULL;
     StatusBar *bar = NULL;
     DynamicGui*dynamic_gui = NULL;


### PR DESCRIPTION
Use day/month format for 24 hour format. Use month/day format for 12 hour format.

The only thing I can't solve is the "jumping around on the screen" of the time, am/pm, and seconds, when you first start the watch. I tried to hide all of those elements until after they were aligned, but it didn't make any difference.