### PR TITLE
SK Websocket connection fix + enhancement

### DIFF
--- a/src/networking/signalk_socket.cpp
+++ b/src/networking/signalk_socket.cpp
@@ -488,7 +488,7 @@ void SignalKSocket::send_status_message()
     JsonObject temp = values.createNestedObject();
     sprintf(buff, "%s.temperature", device_name_);
     temp["path"] = buff;
-    temp["value"] =  (274.15f + TTGOClass::getWatch()->power->getTemp());
+    temp["value"] =  (273.15f + TTGOClass::getWatch()->power->getTemp());
 
     if (serializeJson(statusJson, buff))
     {


### PR DESCRIPTION
I've fixed WS connection process to connect right after websocket is connected not after welcome message is received. Tested it with my RPI and it works fine, should be more reliable then before.

Another enhancement requested by @ba58smith was sending watch status in separate SK paths, this PR does it. INew paths are:
{watchname}.battery = 53
{watchname}.temperature = 288
{watchname}.uptime = "19:43:45" (data are from my watch on my desk)

Thanks