### PR TITLE
In DynamicView Binding, use multiply and offset correctly.

### DIFF
--- a/src/ui/dynamic_label.cpp
+++ b/src/ui/dynamic_label.cpp
@@ -139,7 +139,7 @@ void DynamicLabel::update(const JsonVariant &value)
     }
     else if (value.is<float>())
     {
-        stringValue = String((value.as<float>() + formating.offset) * formating.multiply, formating.decimal_places);
+        stringValue = String((value.as<float>() * formating.multiply) + formating.offset, formating.decimal_places);
     }
     else if (value.is<bool>())
     {


### PR DESCRIPTION
It was "add offset, then multiply". It should be "multiply, then add offset".

I tested this with the conversion of the watch CPU temperature from Kelvin to Fahrenheit.

Fixes Issue #75.