### PR TITLE
Fixed label update issue - int type

### DIFF
--- a/src/ui/dynamic_label.cpp
+++ b/src/ui/dynamic_label.cpp
@@ -95,7 +95,7 @@ void DynamicLabel::update(const JsonVariant &value)
     }
     else if (value.is<int>())
     {
-        stringValue = String(value.as<int>());
+        stringValue = String(((float)value.as<int>() * formating.multiply) + formating.offset, formating.decimal_places);
     }
     else if (value.is<float>())
     {


### PR DESCRIPTION
DynamicLabel had issue when SK delta value was convertable to int it would not apply offset and multiply.

Fixes #94 and adds proper handling of int JSON values.

Will merge it right the way as it's simple fix.